### PR TITLE
Remove point limit slider from dashboards

### DIFF
--- a/webapp/pages/technical_indicators.py
+++ b/webapp/pages/technical_indicators.py
@@ -63,8 +63,18 @@ else:  # RSI
     rs = avg_gain / avg_loss
     df['indicator'] = 100 - (100 / (1 + rs))
 
-point_limit = st.slider("🔢 Liczba ostatnich punktów", min_value=10, max_value=1000, value=200, step=10)
-df = df.tail(point_limit)
+
+# Zakres wolumenu
+min_volume = float(df['volume'].min())
+max_volume = float(df['volume'].max())
+volume_range = st.slider(
+    "📈 Zakres wolumenu",
+    min_value=min_volume,
+    max_value=max_volume,
+    value=(min_volume, max_volume)
+)
+
+df = df[(df['volume'] >= volume_range[0]) & (df['volume'] <= volume_range[1])]
 
 def candlestick_chart(data: pd.DataFrame):
     base = alt.Chart(data)


### PR DESCRIPTION
## Summary
- fetch volume data for price tracker dashboard
- add volume filter slider to main dashboard
- add volume filter slider to technical indicators dashboard

## Testing
- `python -m py_compile webapp/app.py webapp/pages/technical_indicators.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b2aedaac88324acbf0f2dcfc5ed6f